### PR TITLE
refactoring: Use trailing arguments directly as inputs

### DIFF
--- a/src/sort.d
+++ b/src/sort.d
@@ -1,6 +1,5 @@
 module importsort.sort;
 
-import argparse;
 import importsort.main : SortConfig;
 import std.algorithm : findSplit, remove, sort;
 import std.array : split;


### PR DESCRIPTION
Still thinking about how to better indicate the trailing arguments as inputs. Not sure that this is something that argparse can do in its automatically generated help-text. (thats why i went for --inputs as option, but now with trailing arguments its nicer from a commandline perspective!).
